### PR TITLE
Add Laravel 13 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "ext-gd": "*",
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^11.0|^12.0"
+        "illuminate/contracts": "^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",


### PR DESCRIPTION
This update adds Laravel 13 support by extending the illuminate/contracts version constraint to include ^13.0.

The package installs and works correctly on Laravel 13 after this change. No breaking changes were introduced, and all existing functionality remains compatible with the updated framework version.